### PR TITLE
Update GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,19 +1,40 @@
 name: Build and Deploy
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-
-    runs-on: macos-latest
-
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: pandoc/core:latest
     steps:
-    - uses: actions/checkout@v2
-    - name: install
-      run: brew install pandoc
-    - name: build
-      run: sh ./build.sh
-    - uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dst
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build site
+        run: sh ./build.sh
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dst
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ sh build.sh
 
 ## Deploy
 
-When new changes are pushed to the master branch, GitHub Actions will automatically build and deploy the page to GitHub Pages.
+When new changes are pushed to the **main** branch, GitHub Actions builds the site in a container with pandoc and deploys directly to GitHub Pages.


### PR DESCRIPTION
## Summary
- limit GitHub Pages deployment to `main`
- build site in a pandoc container and deploy using `deploy-pages`
- update documentation for the new deployment process

## Testing
- `sh build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856d2ed4d4483278d800ff0ad5bb47a